### PR TITLE
Fix GH Actions not working with dependabot

### DIFF
--- a/.github/workflows/dependabot-fix.yml
+++ b/.github/workflows/dependabot-fix.yml
@@ -28,12 +28,15 @@ jobs:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
     steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.MENMOS_BOT_APP_ID }}
+          private_key: ${{ secrets.MENMOS_BOT_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v2.3.5
         with:
-          # Using a Personal Access Token here is required to trigger workflows on our new commit.
-          # The default GitHub token doesn't trigger any workflows.
-          # See: https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854/2
-          token: ${{ secrets.DEPENDABOT_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 2
 


### PR DESCRIPTION
This PR should fix Github Actions not working with dependabot by using an App Token instead of a Private Access Token (PAT).