### PR TITLE
[MEN-138] - Add /web path prefix

### DIFF
--- a/src/components/profile.tsx
+++ b/src/components/profile.tsx
@@ -31,7 +31,7 @@ const Profile: FC<Properties> = (properties) => {
 
   const onLogout = () => {
     logout()
-    navigate('/login')
+    navigate('login')
   }
 
   return (

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -21,7 +21,7 @@ export const Home: FC = (): JSX.Element => {
     }
 
     if (!isAuthenticated()) {
-      navigate('/login')
+      navigate('login')
     }
 
     setIsLoading(false)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,10 +16,11 @@ const app = document.querySelector('#app')
 ReactDOM.render(
   <ThemeProvider theme={theme}>
     <CssBaseline />
-    <HistoryRouter history={history}>
+    <HistoryRouter history={history} basename="/web">
       <Routes>
         <Route path="/" element={<Home />} />
-        <Route path="/login" element={<Login />} />
+        <Route path="login" element={<Login />} />
+        <Route path="*" element={<p>Not found</p>} />
       </Routes>
     </HistoryRouter>
   </ThemeProvider>,

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -1,6 +1,6 @@
 describe('Login', () => {
   it('Should go to the login page automatically', () => {
-    cy.visit('/')
+    cy.visit('/web')
 
     cy.url().should('include', '/login')
   })

--- a/tests/logout.spec.ts
+++ b/tests/logout.spec.ts
@@ -14,7 +14,7 @@ describe('Search', () => {
     cy.get('#logout').click()
 
     cy.url().should('include', '/login')
-    cy.visit('/')
+    cy.visit('/web')
     cy.url().should('include', '/login')
   })
 })

--- a/tests/logout.spec.ts
+++ b/tests/logout.spec.ts
@@ -4,7 +4,7 @@ describe('Search', () => {
   it('Should log in programmatically without using the UI', () => {
     login()
 
-    cy.visit('/')
+    cy.visit('/web')
   })
 
   it('Should log the user out of the web app', () => {

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -4,7 +4,7 @@ describe('Search', () => {
   it('Should log in programmatically without using the UI', () => {
     login()
 
-    cy.visit('/')
+    cy.visit('/web')
   })
 
   it('Should search for blobs with a given tag', async () => {


### PR DESCRIPTION
This PR adds the `/web` prefix added by axum to react-router so it handles routing properly when served with Menmos.  