### PR TITLE
Fix a problem between VSCode and Yarn 3

### DIFF
--- a/.yarn/sdks/prettier/package.json
+++ b/.yarn/sdks/prettier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier",
-  "version": "2.6.1-sdk",
+  "version": "2.6.2-sdk",
   "main": "./index.js",
   "type": "commonjs"
 }

--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -61,16 +61,24 @@ const moduleWrapper = tsserver => {
           //
           // Ref: https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
           //
-          // Update Oct 8 2021: VSCode changed their format in 1.61.
+          // Update 2021-10-08: VSCode changed their format in 1.61.
           // Before | ^zip:/c:/foo/bar.zip/package.json
           // After  | ^/zip//c:/foo/bar.zip/package.json
+          //
+          // Update 2022-04-06: VSCode changed the format in 1.66.
+          // Before | ^/zip//c:/foo/bar.zip/package.json
+          // After  | ^/zip/c:/foo/bar.zip/package.json
           //
           case `vscode <1.61`: {
             str = `^zip:${str}`;
           } break;
 
-          case `vscode`: {
+          case `vscode <1.66`: {
             str = `^/zip/${str}`;
+          } break;
+
+          case `vscode`: {
+            str = `^/zip${str}`;
           } break;
 
           // To make "go to definition" work,
@@ -160,8 +168,12 @@ const moduleWrapper = tsserver => {
         typeof parsedMessage.arguments.hostInfo === `string`
       ) {
         hostInfo = parsedMessage.arguments.hostInfo;
-        if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK && process.env.VSCODE_IPC_HOOK.match(/Code\/1\.([1-5][0-9]|60)\./)) {
-          hostInfo += ` <1.61`;
+        if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK) {
+          if (/(\/|-)1\.([1-5][0-9]|60)\./.test(process.env.VSCODE_IPC_HOOK)) {
+            hostInfo += ` <1.61`;
+          } else if (/(\/|-)1\.(6[1-5])\./.test(process.env.VSCODE_IPC_HOOK)) {
+            hostInfo += ` <1.66`;
+          }
         }
       }
 

--- a/.yarn/sdks/typescript/lib/tsserverlibrary.js
+++ b/.yarn/sdks/typescript/lib/tsserverlibrary.js
@@ -61,16 +61,24 @@ const moduleWrapper = tsserver => {
           //
           // Ref: https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
           //
-          // Update Oct 8 2021: VSCode changed their format in 1.61.
+          // Update 2021-10-08: VSCode changed their format in 1.61.
           // Before | ^zip:/c:/foo/bar.zip/package.json
           // After  | ^/zip//c:/foo/bar.zip/package.json
+          //
+          // Update 2022-04-06: VSCode changed the format in 1.66.
+          // Before | ^/zip//c:/foo/bar.zip/package.json
+          // After  | ^/zip/c:/foo/bar.zip/package.json
           //
           case `vscode <1.61`: {
             str = `^zip:${str}`;
           } break;
 
-          case `vscode`: {
+          case `vscode <1.66`: {
             str = `^/zip/${str}`;
+          } break;
+
+          case `vscode`: {
+            str = `^/zip${str}`;
           } break;
 
           // To make "go to definition" work,
@@ -160,8 +168,12 @@ const moduleWrapper = tsserver => {
         typeof parsedMessage.arguments.hostInfo === `string`
       ) {
         hostInfo = parsedMessage.arguments.hostInfo;
-        if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK && process.env.VSCODE_IPC_HOOK.match(/Code\/1\.([1-5][0-9]|60)\./)) {
-          hostInfo += ` <1.61`;
+        if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK) {
+          if (/(\/|-)1\.([1-5][0-9]|60)\./.test(process.env.VSCODE_IPC_HOOK)) {
+            hostInfo += ` <1.61`;
+          } else if (/(\/|-)1\.(6[1-5])\./.test(process.env.VSCODE_IPC_HOOK)) {
+            hostInfo += ` <1.66`;
+          }
         }
       }
 


### PR DESCRIPTION
This PR fixes a problem that was caused by some update of VSCode which breaks the integration with Yarn 3 making it impossible to open the code of dependencies.